### PR TITLE
Handle unregistered functions cleanly in `BaseStore.deregister`

### DIFF
--- a/store.js
+++ b/store.js
@@ -29,7 +29,9 @@
     };
 
     this.deregister = function(fn) {
-      registry.splice(registry.indexOf(fn), 1);
+      var i = registry.indexOf(fn);
+      if (i != -1)
+        registry.splice(i, 1);
     };
 
     this.reset = function() {


### PR DESCRIPTION
This PR fixes a bug whereby attempting to deregister a function that was not previously registered would result in the removal of the most recently registered function.
